### PR TITLE
ngrx-store init and update action support

### DIFF
--- a/src/handleUndo.ts
+++ b/src/handleUndo.ts
@@ -1,11 +1,15 @@
 import { Action, ActionReducer } from '@ngrx/store';
 import { UNDO_ACTION } from './undoAction';
 
+const STORE_INIT_ACTION = '@ngrx/store/init';
+const STORE_UPDATE_ACTION = '@ngrx/store/update-reducers';
 
 let bufferSize = 100;
+
 export function configureBufferSize(size: number): void {
     bufferSize = size;
 }
+
 export function handleUndo(rootReducer: ActionReducer<any>): ActionReducer<any> {
     let executedActions: Array<Action> = [];
     let initialState = undefined;
@@ -22,8 +26,10 @@ export function handleUndo(rootReducer: ActionReducer<any>): ActionReducer<any> 
                 newState = rootReducer(newState, executedAction));
             return newState;
         }
-        // push every action that isn't an UNDO_ACTION to the executedActions property
-        executedActions.push(action);
+        if (!(action.type === STORE_INIT_ACTION || action.type === STORE_UPDATE_ACTION)) {
+            // push every action that isn't an UNDO_ACTION, STORE_INIT_ACTION, or STORE_UPDATE_ACTION to the executedActions property
+            executedActions.push(action);
+        }
         let updatedState = rootReducer(state, action);
         if (executedActions.length === bufferSize + 1) {
             let firstAction = executedActions[0];


### PR DESCRIPTION
The action is only added to the array of executed ones if it's not a store init or update action either, so when the buffer size is reached, the store won't reset to its initial state.